### PR TITLE
Update metadata.json to support GNOME 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Allow remote desktop connections when the screen is locked",
   "version": 4600,
   "uuid": "allowlockedremotedesktop@kamens.us",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "session-modes": ["user", "unlock-dialog"],
   "url": "https://github.com/jikamens/allow-locked-remote-desktop/"
 }


### PR DESCRIPTION
I can confirm that the extension works in gnome 47 without any changes.